### PR TITLE
Startup Improvements

### DIFF
--- a/ts/common/cli.ts
+++ b/ts/common/cli.ts
@@ -211,7 +211,7 @@ export class Cli {
   /**
    * Method for the command line interface of the Speech Rule Engine
    */
-  public commandLine() {
+  public async commandLine() {
     const commander = SystemExternal.commander;
     const system = System;
     const set = ((key: string) => {
@@ -336,7 +336,7 @@ export class Cli {
         this.enumerate(true).then(() => System.exit(0));
       })
       .parse(this.process.argv);
-    System.setupEngine(this.setup);
+    await System.setupEngine(this.setup);
     const options = commander.opts();
     if (options.verbose) {
       Debugger.getInstance().init(options.log);

--- a/ts/common/engine.ts
+++ b/ts/common/engine.ts
@@ -60,12 +60,12 @@ export default class Engine {
    * String feature vector.
    */
   public static STRING_FEATURES: string[] = [
-    'delay',
     'markup',
     'style',
     'domain',
     'speech',
     'walker',
+    'defaultLocale',
     'locale',
     'modality',
     'rate',
@@ -116,9 +116,14 @@ export default class Engine {
   public style = Dcstr.DynamicCstr.DEFAULT_VALUES[Dcstr.Axis.STYLE];
 
   /**
+   * The default locale.
+   */
+  public defaultLocale = Dcstr.DynamicCstr.DEFAULT_VALUES[Dcstr.Axis.LOCALE];
+
+  /**
    * Current locale.
    */
-  public locale = Dcstr.DynamicCstr.DEFAULT_VALUES[Dcstr.Axis.LOCALE];
+  public locale = this.defaultLocale;
 
   /**
    * Current subiso for the locale.
@@ -245,6 +250,9 @@ export default class Engine {
    *    parameters.
    */
   public setDynamicCstr(opt_dynamic?: Dcstr.AxisMap) {
+    if (this.defaultLocale) {
+      Dcstr.DynamicCstr.DEFAULT_VALUES[Dcstr.Axis.LOCALE] = this.defaultLocale;
+    }
     if (opt_dynamic) {
       const keys = Object.keys(opt_dynamic);
       for (let i = 0; i < keys.length; i++) {

--- a/ts/common/engine.ts
+++ b/ts/common/engine.ts
@@ -98,7 +98,7 @@ export default class Engine {
    */
   public mode: EngineConst.Mode = EngineConst.Mode.SYNC;
 
-  public delay: boolean = false;
+  public init: boolean = true;
 
   /**
    * Maps domains to comparators.
@@ -379,6 +379,6 @@ export class EnginePromise {
    * @returns All promises combined into one.
    */
   public static getall() {
-    return Promise.allSettled(Object.values(EnginePromise.promises));
+    return Promise.all(Object.values(EnginePromise.promises));
   }
 }

--- a/ts/common/engine.ts
+++ b/ts/common/engine.ts
@@ -24,6 +24,7 @@ import * as Dcstr from '../rule_engine/dynamic_cstr';
 import * as EngineConst from './engine_const';
 
 import { Debugger } from './debugger';
+import { Variables } from './variables';
 
 declare const SREfeature: { [key: string]: any };
 
@@ -118,7 +119,15 @@ export default class Engine {
   /**
    * The default locale.
    */
-  public defaultLocale = Dcstr.DynamicCstr.DEFAULT_VALUES[Dcstr.Axis.LOCALE];
+  public _defaultLocale = Dcstr.DynamicCstr.DEFAULT_VALUES[Dcstr.Axis.LOCALE];
+
+  public set defaultLocale(loc: string) {
+    this._defaultLocale = Variables.ensureLocale(loc, this._defaultLocale);
+  }
+
+  public get defaultLocale() {
+    return this._defaultLocale;
+  }
 
   /**
    * Current locale.

--- a/ts/common/engine_setup.ts
+++ b/ts/common/engine_setup.ts
@@ -72,12 +72,13 @@ export async function setup(feature: { [key: string]: boolean | string }) {
   setupBrowsers(engine);
   L10n.setLocale();
   engine.setDynamicCstr();
-  if (engine.delay) {
-    // We add a break in the execution flow.
-    EnginePromise.promises['delay'] = new Promise((res, _rej) => {
-      setTimeout(() => {res('');}, 10)
+  // We add a break in the execution flow so custom loaders can set up.
+  if (engine.init) {
+    EnginePromise.promises['init'] = new Promise((res, _rej) => {
+      setTimeout(() => {
+        res('init');}, 10)
     });
-    engine.delay = false;
+    engine.init = false;
     return EnginePromise.get();
   }
   return MathMap.init().then(() => {

--- a/ts/common/engine_setup.ts
+++ b/ts/common/engine_setup.ts
@@ -73,6 +73,10 @@ export async function setup(feature: { [key: string]: boolean | string }) {
   L10n.setLocale();
   engine.setDynamicCstr();
   if (engine.delay) {
+    // We add a break in the execution flow.
+    EnginePromise.promises['delay'] = new Promise((res, _rej) => {
+      setTimeout(() => {res('');}, 10)
+    });
     engine.delay = false;
     return EnginePromise.get();
   }

--- a/ts/common/system.ts
+++ b/ts/common/system.ts
@@ -408,9 +408,10 @@ export const localePath = FileUtil.localePath;
 
 // Check here for custom method!
 if (SystemExternal.documentSupported) {
-  setupEngine({ mode: EngineConst.Mode.HTTP, delay: true });
+  setupEngine({ mode: EngineConst.Mode.HTTP }).then(() =>
+    setupEngine({}));
 } else {
-  setupEngine({ mode: EngineConst.Mode.SYNC, delay: true }).then(() =>
+  setupEngine({ mode: EngineConst.Mode.SYNC }).then(() =>
     setupEngine({ mode: EngineConst.Mode.ASYNC })
   );
 }

--- a/ts/common/system.ts
+++ b/ts/common/system.ts
@@ -408,9 +408,9 @@ export const localePath = FileUtil.localePath;
 
 // Check here for custom method!
 if (SystemExternal.documentSupported) {
-  setupEngine({ mode: EngineConst.Mode.HTTP });
+  setupEngine({ mode: EngineConst.Mode.HTTP, delay: true });
 } else {
-  setupEngine({ mode: EngineConst.Mode.SYNC }).then(() =>
+  setupEngine({ mode: EngineConst.Mode.SYNC, delay: true }).then(() =>
     setupEngine({ mode: EngineConst.Mode.ASYNC })
   );
 }

--- a/ts/common/variables.ts
+++ b/ts/common/variables.ts
@@ -43,6 +43,23 @@ export class Variables {
   ];
 
   /**
+   * Ensures a locale exists. If the given locale does not exist, it returns the
+   * default instead.
+   *
+   * @param loc The locale in question.
+   * @param def A default locale.
+   * @return The existing locale. The default is returned if `loc` does not
+   *      exist. There is no further check on `def`, however!
+   */
+  public static ensureLocale(loc: string, def: string): string {
+    if (Variables.LOCALES.indexOf(loc) === -1) {
+      console.error('Locale ' + loc + ' does not exist! Using en instead.');
+      return def;
+    }
+    return loc;
+  }
+
+  /**
    * MathJax version. This is useful for paths depending on MathJax
    * distribution.
    */

--- a/ts/l10n/l10n.ts
+++ b/ts/l10n/l10n.ts
@@ -91,13 +91,10 @@ function setSubiso(msg: Locale) {
  * @returns A message object.
  */
 export function getLocale(): Locale {
-  const locale = Engine.getInstance().locale;
-  if (Variables.LOCALES.indexOf(locale) === -1) {
-    console.error('Locale ' + locale + ' does not exist! Using en instead.');
-    Engine.getInstance().locale = Engine.getInstance().defaultLocale;
-  }
-  return (locales[Engine.getInstance().locale] ||
-    locales[Engine.getInstance().defaultLocale])();
+  const locale = Variables.ensureLocale(
+    Engine.getInstance().locale, Engine.getInstance().defaultLocale);
+  Engine.getInstance().locale = locale;
+  return locales[locale]();
 }
 
 /**

--- a/ts/l10n/l10n.ts
+++ b/ts/l10n/l10n.ts
@@ -94,9 +94,10 @@ export function getLocale(): Locale {
   const locale = Engine.getInstance().locale;
   if (Variables.LOCALES.indexOf(locale) === -1) {
     console.error('Locale ' + locale + ' does not exist! Using en instead.');
-    Engine.getInstance().locale = 'en';
+    Engine.getInstance().locale = Engine.getInstance().defaultLocale;
   }
-  return (locales[Engine.getInstance().locale] || locales['en'])();
+  return (locales[Engine.getInstance().locale] ||
+    locales[Engine.getInstance().defaultLocale])();
 }
 
 /**

--- a/ts/rule_engine/dynamic_cstr.ts
+++ b/ts/rule_engine/dynamic_cstr.ts
@@ -148,6 +148,11 @@ export class DynamicCstr extends DynamicProperties {
   /**
    *  Default values for to assign. Value is default.
    */
+  public static BASE_LOCALE = 'base';
+
+  /**
+   *  Default values for to assign. Value is default.
+   */
   public static DEFAULT_VALUE = 'default';
 
   /**

--- a/ts/speech_rules/clearspeak_rules.ts
+++ b/ts/speech_rules/clearspeak_rules.ts
@@ -18,6 +18,7 @@
  * @author v.sorge@mathjax.org (Volker Sorge)
  */
 
+import { DynamicCstr } from '../rule_engine/dynamic_cstr';
 import * as StoreUtil from '../rule_engine/store_util';
 
 import * as ClearspeakUtil from './clearspeak_util';
@@ -30,7 +31,8 @@ import * as SpeechRules from './speech_rules';
  */
 export function ClearspeakRules() {
   // Basic English
-  SpeechRules.addStore('en.speech.clearspeak', '', {
+  SpeechRules.addStore(
+    DynamicCstr.BASE_LOCALE + '.speech.clearspeak', '', {
     CTFpauseSeparator: StoreUtil.pauseSeparator,
     CTFnodeCounter: ClearspeakUtil.nodeCounter,
     CTFcontentIterator: StoreUtil.contentIterator,

--- a/ts/speech_rules/math_map.ts
+++ b/ts/speech_rules/math_map.ts
@@ -27,6 +27,7 @@ import * as EngineConst from '../common/engine_const';
 import * as FileUtil from '../common/file_util';
 import SystemExternal from '../common/system_external';
 import { RulesJson } from '../rule_engine/base_rule_store';
+import { DynamicCstr } from '../rule_engine/dynamic_cstr';
 import * as MathCompoundStore from '../rule_engine/math_compound_store';
 import { SiJson, UnicodeJson } from '../rule_engine/math_simple_store';
 import { SpeechRuleEngine } from '../rule_engine/speech_rule_engine';
@@ -68,10 +69,10 @@ let _init = false;
  */
 export async function loadLocale(locale = Engine.getInstance().locale) {
   if (!_init) {
-    _loadLocale('base');
+    _loadLocale(DynamicCstr.BASE_LOCALE);
     _init = true;
   }
-  return EnginePromise.promises['base'].then(async () => {
+  return EnginePromise.promises[DynamicCstr.BASE_LOCALE].then(async () => {
     let defLoc = Engine.getInstance().defaultLocale;
     if (defLoc) {
       _loadLocale(defLoc)

--- a/ts/speech_rules/math_map.ts
+++ b/ts/speech_rules/math_map.ts
@@ -71,7 +71,15 @@ export async function loadLocale(locale = Engine.getInstance().locale) {
     _loadLocale('base');
     _init = true;
   }
-  return EnginePromise.promises['base'].then(() => {
+  return EnginePromise.promises['base'].then(async () => {
+    let defLoc = Engine.getInstance().defaultLocale;
+    if (defLoc) {
+      _loadLocale(defLoc)
+      return EnginePromise.promises[defLoc].then(async () => {
+        _loadLocale(locale);
+        return EnginePromise.promises[locale];
+      });
+    }
     _loadLocale(locale);
     return EnginePromise.promises[locale];
   });
@@ -140,7 +148,7 @@ export function retrieveFiles(locale: string) {
       (_err: string) => {
         EnginePromise.loaded[locale] = [true, false];
         console.error(`Unable to load locale: ${locale}`);
-        Engine.getInstance().locale = 'en';
+        Engine.getInstance().locale = Engine.getInstance().defaultLocale;
         res(locale);
       }
     );

--- a/ts/speech_rules/mathspeak_rules.ts
+++ b/ts/speech_rules/mathspeak_rules.ts
@@ -18,6 +18,7 @@
  * @author v.sorge@mathjax.org (Volker Sorge)
  */
 
+import { DynamicCstr } from '../rule_engine/dynamic_cstr';
 import * as StoreUtil from '../rule_engine/store_util';
 import * as MathspeakFrenchUtil from './mathspeak_french_util';
 import * as MathspeakUtil from './mathspeak_util';
@@ -30,7 +31,8 @@ import * as UnitUtil from './unit_util';
  */
 export function MathspeakRules() {
   // Basic English
-  SpeechRules.addStore('en.speech.mathspeak', '', {
+  SpeechRules.addStore(
+    DynamicCstr.BASE_LOCALE + '.speech.mathspeak', '', {
     CQFspaceoutNumber: MathspeakUtil.spaceoutNumber,
 
     CQFspaceoutIdentifier: MathspeakUtil.spaceoutIdentifier,
@@ -98,13 +100,15 @@ export function MathspeakRules() {
   });
 
   // Spanish
-  SpeechRules.addStore('es.speech.mathspeak', 'en.speech.mathspeak', {
+  SpeechRules.addStore(
+    'es.speech.mathspeak', DynamicCstr.BASE_LOCALE + '.speech.mathspeak', {
     CTFunitMultipliers: UnitUtil.unitMultipliers,
     CQFoneLeft: UnitUtil.oneLeft
   });
 
   // French
-  SpeechRules.addStore('fr.speech.mathspeak', 'en.speech.mathspeak', {
+  SpeechRules.addStore(
+    'fr.speech.mathspeak', DynamicCstr.BASE_LOCALE + '.speech.mathspeak', {
     CSFbaselineVerbose: MathspeakFrenchUtil.baselineVerbose,
     CSFbaselineBrief: MathspeakFrenchUtil.baselineBrief,
     // Tensor specific:

--- a/ts/speech_rules/other_rules.ts
+++ b/ts/speech_rules/other_rules.ts
@@ -18,6 +18,7 @@
  * @author v.sorge@mathjax.org (Volker Sorge)
  */
 
+import { DynamicCstr } from '../rule_engine/dynamic_cstr';
 import { SpeechRuleStore } from '../rule_engine/speech_rule_store';
 import * as StoreUtil from '../rule_engine/store_util';
 
@@ -56,7 +57,8 @@ export function OtherRules() {
  */
 export function BrailleRules() {
   // Basic Nemeth
-  SpeechRules.addStore('nemeth.braille.default', 'en.speech.mathspeak', {
+  SpeechRules.addStore(
+    'nemeth.braille.default', DynamicCstr.BASE_LOCALE + '.speech.mathspeak', {
     CSFopenFraction: NemethUtil.openingFraction,
     CSFcloseFraction: NemethUtil.closingFraction,
     CSFoverFraction: NemethUtil.overFraction,

--- a/ts/speech_rules/speech_rules.ts
+++ b/ts/speech_rules/speech_rules.ts
@@ -57,7 +57,6 @@ export function addStore(
  * @param domain The rule set or domain.
  * @returns The store for the given constraints.
  */
-// TODO: Make this robust with dynamic constraints and defaults.
 export function getStore(
   locale: string,
   modality: string,
@@ -67,6 +66,9 @@ export function getStore(
     funcStore.get([locale, modality, domain].join('.')) ||
     funcStore.get(
       [DynamicCstr.DEFAULT_VALUES[Axis.LOCALE], modality, domain].join('.')
+    ) ||
+    funcStore.get(
+      [DynamicCstr.BASE_LOCALE, modality, domain].join('.')
     ) ||
     {}
   );


### PR DESCRIPTION
Ensures cleaner handling of locale loading on SRE startup. In particular, this PR 

* removes the `delay` flag.
* sequences promises for loading of `base`, `default` and selected locale
* ensure `engineReady` waits for all locales to be loaded
* adds customisation for `defaultLocale`
* correct inheritance of function stores from a base store, rather than English. This failed, when English is **not** the default.