### PR TITLE
Fixes error when XHR has wrapper and returns proper js object instead the string.

### DIFF
--- a/ts/speech_rules/math_map.ts
+++ b/ts/speech_rules/math_map.ts
@@ -165,8 +165,10 @@ function retrieveFiles(locale: string) {
  *
  * @param json The json mappings string.
  */
-function parseMaps(json: string) {
-  const js = JSON.parse(json) as { [key: string]: any[] };
+function parseMaps(json: string | MathMapJson) {
+  const js = (typeof json === 'string') ?
+      JSON.parse(json) as { [key: string]: any[] }
+      : json;
   addMaps(js);
 }
 


### PR DESCRIPTION
Fixes error when XHR has wrapper and returns proper js object instead of the string.