### PR TITLE
adds some literal Braille translation for alt texts

### DIFF
--- a/mathmaps/euro/rules/euro.json
+++ b/mathmaps/euro/rules/euro.json
@@ -12,6 +12,14 @@
     ],
     [
       "Rule",
+      "direct-speech",
+      "default",
+      "[t] @ext-speech (grammar:literal)",
+      "self::*[@ext-speech]",
+      "priority=Infinity"
+    ],
+    [
+      "Rule",
       "latex",
       "default",
       "[n] @latex",

--- a/mathmaps/nemeth/rules/nemeth.json
+++ b/mathmaps/nemeth/rules/nemeth.json
@@ -11,6 +11,14 @@
       "CQFresetNesting"
     ],
     [
+      "Rule",
+      "direct-speech",
+      "default",
+      "[t] @ext-speech (grammar:literal)",
+      "self::*[@ext-speech]",
+      "priority=Infinity"
+    ],
+    [
       "Precondition",
       "unknown",
       "default",

--- a/ts/speech_rules/nemeth_util.ts
+++ b/ts/speech_rules/nemeth_util.ts
@@ -481,3 +481,11 @@ export function contentIterator(nodes: Element[], context: string) {
     return descrs;
   };
 }
+
+function literal(text: string) {
+  const evalStr = (e: string) =>
+    Engine.getInstance().evaluator(e, Engine.getInstance().dynamicCstr);
+  return Array.from(text).map(evalStr).join('');
+}
+
+Grammar.getInstance().setCorrection('literal', literal);


### PR DESCRIPTION
Mostly fixes issue #665 .
The only exception are numbers in nemeth Braille, which do not get the correct prefix number symbol. 